### PR TITLE
Add RSS news feed endpoint

### DIFF
--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -250,6 +250,34 @@ export const openapiSpec = openapi({
           ] as OpenAPIV3.ParameterObject[],
         },
       },
+      "/news/{sport}/{division}": {
+        get: {
+          summary: "News",
+          description:
+            "News articles and videos for a given sport and division. Returns parsed RSS feed data in JSON format.\n\nhttps://www.ncaa.com/news/basketball-men/d1/rss.xml",
+          parameters: [
+            {
+              name: "sport",
+              in: "path",
+              schema: { type: "string" },
+              required: true,
+              examples: makeExamples([
+                "basketball-men",
+                "basketball-women",
+                "football",
+                "volleyball-women",
+              ]),
+            },
+            {
+              name: "division",
+              in: "path",
+              schema: { type: "string" },
+              required: true,
+              examples: makeExamples(["d1", "d2", "d3", "fbs", "fcs"]),
+            },
+          ] as OpenAPIV3.ParameterObject[],
+        },
+      },
       "/schedule/{sport}/{division}/{path}": {
         get: {
           summary: "Schedule",


### PR DESCRIPTION

## Summary
Adds /news/:sport/:division endpoint to fetch and parse NCAA RSS feeds into JSON format.

## Example Response
`
{
  "title": "NCAA.com > football fcs articles and video",
  "link": "https://www.ncaa.com/news/football/fcs/rss.xml",
  "description": "NCAA.com > football fcs Articles",
  "language": "en",
  "items": [
    {
      "title": "South Carolina State vs. Prairie View A&M: Time, TV channel, preview for the 2025 Celebration Bowl",
      "link": "https://www.ncaa.com/live-updates/football/fcs/south-carolina-state-vs-prairie-view-am-time-tv-channel-preview-2025-celebration-bowl",
      "description": "Everything you need to know for the 2025 Celebration Bowl between Prairie View A&M and South Carolina State.",
      "image": "https://www.ncaa.com/_flysystem/public-s3/styles/small_16x9/public-s3/images/2025-12/south-carolina-state-prairie-view-am-football-swac-meac-celebration-bowl-2025.jpg?h=5910dae1&itok=49zZzKqc",
      "pubDate": "Mon, 08 Dec 2025 21:04:00 +0000",
      "creator": "Stan Becton",
      "category": "FCS Football",
      "enclosure": "https://www.ncaa.com/_flysystem/public-s3/styles/large_16x9/public-s3/images/2025-12/south-carolina-state-prairie-view-am-football-swac-meac-celebration-bowl-2025.jpg?h=5910dae1&itok=1kllZHPH"
    }
  ]
}
`

## Changes
- Added /news/:sport/:division endpoint in src/index.ts
- Added OpenAPI documentation in src/openapi.ts
